### PR TITLE
fix(guidedcli): extend AppLabelKey to pod lookup + make listPodsSafe RBAC-aware

### DIFF
--- a/client/kubernetes.go
+++ b/client/kubernetes.go
@@ -180,8 +180,13 @@ func GetLabels(ctx context.Context, namespace string, key string) ([]string, err
 }
 
 // GetContainersWithAppLabel retrieves all containers along with their pod names and app labels
-// in the specified namespace
-func GetContainersWithAppLabel(ctx context.Context, namespace string) ([]map[string]string, error) {
+// in the specified namespace. appLabelKey lets the caller pick the label that identifies
+// the app on each pod (e.g. "app" for TrainTicket, "app.kubernetes.io/name" for otel-demo);
+// empty string falls back to "app" to preserve legacy behavior.
+func GetContainersWithAppLabel(ctx context.Context, namespace, appLabelKey string) ([]map[string]string, error) {
+	if appLabelKey == "" {
+		appLabelKey = "app"
+	}
 	result := []map[string]string{}
 
 	// List all pods in the specified namespace
@@ -193,7 +198,7 @@ func GetContainersWithAppLabel(ctx context.Context, namespace string) ([]map[str
 	}
 
 	for _, pod := range podList.Items {
-		appLabel := pod.Labels["app"]
+		appLabel := pod.Labels[appLabelKey]
 
 		// Add each container with its pod name and app label
 		for _, container := range pod.Spec.Containers {

--- a/client/kubernetes_test.go
+++ b/client/kubernetes_test.go
@@ -50,7 +50,7 @@ func TestCRDClient1(t *testing.T) {
 }
 
 func TestGetContainersWithAppLabel(t *testing.T) {
-	containerInfos, err := GetContainersWithAppLabel(context.Background(), "ts0")
+	containerInfos, err := GetContainersWithAppLabel(context.Background(), "ts0", "app")
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/resourcelookup/lookup.go
+++ b/internal/resourcelookup/lookup.go
@@ -554,7 +554,7 @@ func (s *systemCache) GetAllContainers(ctx context.Context, namespace string) ([
 		}
 	}
 
-	containers, err := client.GetContainersWithAppLabel(ctx, namespace)
+	containers, err := client.GetContainersWithAppLabel(ctx, namespace, systemconfig.GetAppLabelKey(s.system))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/guidedcli/k8s.go
+++ b/pkg/guidedcli/k8s.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"github.com/OperationsPAI/chaos-experiment/internal/resourcelookup"
 	"github.com/OperationsPAI/chaos-experiment/internal/serviceendpoints"
@@ -75,9 +76,12 @@ func safeContainers(namespace string) ([]resourcelookup.ContainerInfo, error) {
 }
 
 func listPodsSafe(namespace string) ([]corev1.Pod, error) {
-	config, err := buildKubeconfigSafe()
+	config, err := rest.InClusterConfig()
 	if err != nil {
-		return nil, err
+		config, err = buildKubeconfigSafe()
+		if err != nil {
+			return nil, err
+		}
 	}
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {


### PR DESCRIPTION
## Summary

Follow-up to 520f0db (*"add per-system AppLabelKey"*) which replaced 13 hardcoded `LabelSelector{"app": ...}` sites in `chaos/*.go` but missed the introspection path. Two gaps:

1. `client.GetContainersWithAppLabel()` still read `pod.Labels["app"]` directly — for `otel-demo` pods (which expose only `app.kubernetes.io/name`) this returns empty, so `resourcelookup.GetAllContainers` is empty, so `handler.GetGroundtruth` → `resolveContainerLevel` crashes with:
    ```
    container index out of range: N (max: -1)
    ```

2. `pkg/guidedcli/k8s.go:listPodsSafe` went straight to `buildKubeconfigSafe()` (file-based kubeconfig) without first trying `rest.InClusterConfig()`. Sister function `listNamespacesSafe` (systems.go:52-59) already does the correct InCluster-first-then-file fallback. In-cluster callers (e.g. AegisLab backend running `guidedcli.BuildInjection`) fail with:
    ```
    kubeconfig not found in default locations
    ```
    despite the pod's ServiceAccount having full RBAC.

## Changes

- `client/kubernetes.go`: `GetContainersWithAppLabel(ctx, ns)` → `GetContainersWithAppLabel(ctx, ns, appLabelKey)`; empty `appLabelKey` falls back to `"app"` for backward compat.
- `internal/resourcelookup/lookup.go`: pass `systemconfig.GetAppLabelKey(s.system)` into the new parameter.
- `pkg/guidedcli/k8s.go`: `listPodsSafe` now tries `rest.InClusterConfig()` first, falls back to `buildKubeconfigSafe()` — same pattern as `listNamespacesSafe`.
- `client/kubernetes_test.go`: update one call site for the new signature.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short ./pkg/guidedcli/... ./client/... ./internal/resourcelookup/...` (new failures = none; pre-existing `TestHandler2` / `TestCRDClient*` cluster-dependent failures are identical on pristine `origin/main`)
- [x] End-to-end verified: AegisLab in-cluster backend, `aegisctl inject guided --apply` against `otel-demo` → request now reaches trace-creation and groundtruth resolution (was 500 on both gaps before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)